### PR TITLE
Refactor `_make_iter` method

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
-name: python lint
+name: lint
+
 on:
-  ['push', 'pull_request']
+  'pull_request':
+    branches:
+      - main
+
 jobs:
   build:
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,7 +1,9 @@
 name: unittests
 
 on:
-  ['push', 'pull_request']
+  'pull_request':
+    branches:
+      - main
 
 jobs:
   build:

--- a/src/fandas/modules/experiment.py
+++ b/src/fandas/modules/experiment.py
@@ -144,7 +144,6 @@ class Experiment:
         combinations = []
         for resnum in range(first_resnum, last_resnum + 1):
             for e in itertools.product(*direction):
-
                 # Fetch residues based on adjusted indices
                 residues = [
                     shifts.residues[resnum + offset]

--- a/tests/modules/test_experiment.py
+++ b/tests/modules/test_experiment.py
@@ -1,14 +1,16 @@
 """Test the experiment module."""
 
-import pytest
-import tempfile
 import os
+import tempfile
 from pathlib import Path
-from fandas.modules.experiment import Experiment
+
+import pytest
+
 from fandas.modules.chemical_shift import ChemShift
+from fandas.modules.experiment import Experiment
 from fandas.modules.input import InputFile
 
-from .. import TEST_INPUT_FILE, TEST_DISTANCE_FILE
+from .. import TEST_DISTANCE_FILE, TEST_INPUT_FILE
 
 
 @pytest.fixture

--- a/tests/modules/test_experiment.py
+++ b/tests/modules/test_experiment.py
@@ -1,4 +1,5 @@
 """Test the experiment module."""
+
 import pytest
 import tempfile
 import os
@@ -90,6 +91,19 @@ def test__make_line(experiment_class, chemical_shifts):
 
 def test__make_iter(experiment_class, chemical_shifts):
     """Test the _make_iter method."""
+
+    observed_iter = experiment_class._make_iter(
+        shifts=chemical_shifts, atom_list=[("H", "H")], direction=[[0], [-1]]
+    )
+    expected_iter = [
+        ((chemical_shifts.residues[2], chemical_shifts.residues[1]), ("H", "H")),
+        ((chemical_shifts.residues[3], chemical_shifts.residues[2]), ("H", "H")),
+        ((chemical_shifts.residues[4], chemical_shifts.residues[3]), ("H", "H")),
+        ((chemical_shifts.residues[5], chemical_shifts.residues[4]), ("H", "H")),
+    ]
+
+    assert observed_iter == expected_iter
+
     observed_iter = experiment_class._make_iter(
         shifts=chemical_shifts, atom_list=[("H", "H")], direction=[[0], [0]]
     )
@@ -119,160 +133,40 @@ def test__make_iter(experiment_class, chemical_shifts):
         ((chemical_shifts.residues[5], chemical_shifts.residues[5]), ("H", "N")),
     ]
 
+    assert observed_iter == expected_iter
+
     observed_iter = experiment_class._make_iter(
         shifts=chemical_shifts,
-        atom_list=[("H", "H", "H"), ("H", "N", "H")],
-        direction=[[0], [0], [+1, 0]],
+        atom_list=[("H", "H", "H")],
+        direction=[[0], [0], [-1, 0, 1]],
     )
 
-    expected_iter = [
+    assert observed_iter[2] == (
         (
-            (
-                chemical_shifts.residues[1],
-                chemical_shifts.residues[1],
-                chemical_shifts.residues[1],
-            ),
-            ("H", "H", "H"),
+            chemical_shifts.residues[2],
+            chemical_shifts.residues[2],
+            chemical_shifts.residues[1],
         ),
-        (
-            (
-                chemical_shifts.residues[1],
-                chemical_shifts.residues[1],
-                chemical_shifts.residues[1],
-            ),
-            ("H", "N", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[2],
-                chemical_shifts.residues[2],
-                chemical_shifts.residues[1],
-            ),
-            ("H", "H", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[2],
-                chemical_shifts.residues[2],
-                chemical_shifts.residues[1],
-            ),
-            ("H", "N", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[2],
-                chemical_shifts.residues[2],
-                chemical_shifts.residues[2],
-            ),
-            ("H", "H", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[2],
-                chemical_shifts.residues[2],
-                chemical_shifts.residues[2],
-            ),
-            ("H", "N", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[3],
-                chemical_shifts.residues[3],
-                chemical_shifts.residues[2],
-            ),
-            ("H", "H", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[3],
-                chemical_shifts.residues[3],
-                chemical_shifts.residues[2],
-            ),
-            ("H", "N", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[3],
-                chemical_shifts.residues[3],
-                chemical_shifts.residues[3],
-            ),
-            ("H", "H", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[3],
-                chemical_shifts.residues[3],
-                chemical_shifts.residues[3],
-            ),
-            ("H", "N", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[4],
-                chemical_shifts.residues[4],
-                chemical_shifts.residues[3],
-            ),
-            ("H", "H", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[4],
-                chemical_shifts.residues[4],
-                chemical_shifts.residues[3],
-            ),
-            ("H", "N", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[4],
-                chemical_shifts.residues[4],
-                chemical_shifts.residues[4],
-            ),
-            ("H", "H", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[4],
-                chemical_shifts.residues[4],
-                chemical_shifts.residues[4],
-            ),
-            ("H", "N", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[5],
-                chemical_shifts.residues[5],
-                chemical_shifts.residues[4],
-            ),
-            ("H", "H", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[5],
-                chemical_shifts.residues[5],
-                chemical_shifts.residues[4],
-            ),
-            ("H", "N", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[5],
-                chemical_shifts.residues[5],
-                chemical_shifts.residues[5],
-            ),
-            ("H", "H", "H"),
-        ),
-        (
-            (
-                chemical_shifts.residues[5],
-                chemical_shifts.residues[5],
-                chemical_shifts.residues[5],
-            ),
-            ("H", "N", "H"),
-        ),
-    ]
+        ("H", "H", "H"),
+    )
 
-    assert observed_iter == expected_iter
+    assert observed_iter[3] == (
+        (
+            chemical_shifts.residues[2],
+            chemical_shifts.residues[2],
+            chemical_shifts.residues[2],
+        ),
+        ("H", "H", "H"),
+    )
+
+    assert observed_iter[4] == (
+        (
+            chemical_shifts.residues[2],
+            chemical_shifts.residues[2],
+            chemical_shifts.residues[3],
+        ),
+        ("H", "H", "H"),
+    )
 
 
 def test_translate_atoms(experiment_class):


### PR DESCRIPTION
This PR refactors the `_make_iter` method, as it was not properly using the negative directions `[0, 0, -1]`