### PR TITLE
remove hardcoded version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "FANDAS"
-version = "2.2.8"
+version = "2.3.0"
 description = "Fast Analysis of multidimensional NMR DAta Sets"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/fandas/version.py
+++ b/src/fandas/version.py
@@ -1,2 +1,5 @@
-VERSION = "2.2.8"
+from importlib.metadata import version as package_version
+
+VERSION = package_version("fandas")
+
 v_major, v_minor, v_patch = VERSION.split(".")


### PR DESCRIPTION
### ==autogenerated==

This pull request includes changes to dynamically set the version of the `fandas` package using the `importlib.metadata` module. This change ensures that the version number is always up-to-date with the installed package version.

* [`src/fandas/version.py`](diffhunk://#diff-c948b14ed793ea42c42c44834296e4d49b15965fa7d1f353768d3171c71fdb32L1-R4): Replaced the hardcoded version string with a dynamic version retrieval using `importlib.metadata`.